### PR TITLE
Update quantum-libraries.md with a new rust simulator

### DIFF
--- a/links/quantum-libraries.md
+++ b/links/quantum-libraries.md
@@ -8,6 +8,7 @@
 - [OpenQL](https://github.com/QE-Lab/OpenQL) - Compiler framework with algorithm libraries, optimizer, scheduler, QEC, mapping, micro-code generator.
 - [ProjectQ](https://github.com/ProjectQ-Framework/ProjectQ) - Hardware-agnostic framework with compiler and simulator with emulation capabilities.
 - [Strawberry Fields](https://github.com/xanaduai/strawberryfields) - [Xanadu](https://www.xanadu.ai)'s software library for photonic quantum computing.
+- [Quriust](https://github.com/ScipioneParmigiano/quriust) - A blazing fast quantum circuit simulator written in Rust. Only for quriust ones.
 
 **Q#**
 - [Q#](https://www.microsoft.com/en-us/quantum/development-kit) - Microsoft's quantum programming language with Visual Studio integration.


### PR DESCRIPTION
Quriust, library for simulating quantum circuits, added to the resources